### PR TITLE
DM-10588: Initial version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: required
+language: c
+services:
+  - docker
+
+script:
+  - "docker build -t ${IMAGE_NAME}:build ."
+
+after_success:
+  - "./travis-deploy.sh"
+
+env:
+  global:
+    # DOCKER_USERNAME
+    - secure: "0snOc6EgeOP2pDDNe1HiRn3kXFWVA2DsrxU3zfpoDrYQOwwj0E0obfXY7eHJEbphTTelDx7rle0hI8+47a7po6MyG3lg2iIWsyvX9SLXUh7h29lN3aUhvSBSrHCuy7MdjaxkeSU1Y8020Zab8xWF3KBVdU3jTTgMOMHiGfc5AuFRu3WzH36bqGGCwOoxoYK25DVag0dXLXspXyOXLMc6Iv62SZgNcmIpoj3eGCm4n00AK+QxakdnicAUuEJ/V9DSHSbSV9bMuS8OMehsMmHx7MXITCQQj0KhwUAcQQpfZmSprjFNvBbvJXoGlH5QViVxnsLdx4aFH6aNM9URLfLRPE3V+RAr928FdbdIXW/dl+kaOXVnOcQGT9vPAkDUZgSp8LZgnt+rcZ9quWzfPsxm26Xp0c8iIGUduENaPdAGyxUIsoDHBEdkgW2xAccaUqFC5d1xglwreqqyQRnXQcJ21B/sgxO5Uzt4z4v5QZWJ83FSU4aO6Pap1WaNVZdboizHDD81HTVXc0JMy4PYIkVBM/CXUUWwggc+w/Gm08OZhxXfsouTXMB7VrIJWdYdidIV3i7f4Yz+pnnWwyOUJuVrzuBixINlfR/dQo/JTM88etnKs8iijAs/gt2VKCMPcYOxga83LRv7KQIGTxtbslizRwSeEIqkiX7UB22qv/Ve/LU="
+    # DOCKER_PASSWORD
+    - secure: "i8zlJkdXiNYpDiwAg3pE1nBxYI/zzw/VxPUvlrI5QR0E+rj+3+S52KAIHq2aG9YPCTEpCOBvruAbXL6NX8pjxqx9/qKmh/tnK3p5SAP8JF1E54TY6DM+DqY9U3eN7IY0aljG1rHYDqpYyD3RR9T3vg1n9uBXHe9AVSGmW6gJ9wdcHrRtBfFlNBrGJbzZoQVTQYTlP4BN3vs/kBm4qm/d3xW6h/kKi1PZORmAs/d+Oj2ashNW9BpCLwcSoxFjpowhpamwID2BdpqixrsgRFzjh1knySeyAvsa6K1Qt6yI+ppN/qnzLUbt3KrC0n6+P8exp4ixJleMt9UKI57u+oGwqzMlumTaRkcIOZrGjWzwlIhMX4IIS8nlTVHU5cMP2ZM8LoQV1NrzBZA6pzxP881JQUmSH/O4acBPfEw102zQbPUI+wjs6Sil+fGSYf/h1UA5mv2pXWvwiSvl/O8lKrf0A0x+P7mlQAz8KeLHbJjherthpZ75mzkxPQ4MvFlqghhgZnPwNjqYk/gKtCzH1VzTJvcCqXAJY6FZCi6bsMyUAP8suT+V/y7TlDNOcQenx9h0vNP21nKl89Um4Sf4xHD1Zh0PjhNIfvnJgaYVoNgSacYyjxF/nNIwR0+tevDAD6J1L4Eb45km9U+el8mhmONtZDkvcyaONlWJhsNF1c3d0bA="
+    - IMAGE_NAME="lsstsqre/lsst-texlive"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# Dockerized texlive
+#
+# https://github.com/lsst-sqre/lsst-texlive
+
+FROM ubuntu:trusty
+MAINTAINER LSST SQuaRE <sqre-admin@lists.lsst.org>
+
+ENV LANG C.UTF-8
+
+# Matches installation in early Travis PDF installations
+# h/t https://github.com/thomasWeise/docker-texlive/blob/master/image/Dockerfile
+# h/t https://github.com/harshjv/docker-texlive-2015/blob/master/Dockerfile
+RUN apt-get update && \
+    apt-get autoclean -y && \
+    apt-get autoremove -y && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        make \
+        git \
+        texlive-fonts-recommended \
+        texlive-latex-extra \
+        texlive-fonts-extra \
+        dvipng \
+        texlive-latex-recommended \
+        latexmk \
+        poppler-utils \
+        latex-xcolor \
+        lmodern \
+        texlive-xetex \
+        texlive-generic-recommended \
+        texlive-full && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* \
+           /tmp/* \
+           /var/tmp/*
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,19 @@ RUN apt-get update && \
         texlive-xetex \
         texlive-generic-recommended \
         texlive-full && \
+    # Purge documentation
+    apt-get purge -f -y \
+        make-doc \
+        texlive-fonts-extra-doc \
+        texlive-fonts-recommended-doc \
+        texlive-humanities-doc \
+        texlive-latex-base-doc \
+        texlive-latex-extra-doc \
+        texlive-latex-recommended-doc \
+        texlive-metapost-doc \
+        texlive-pictures-doc \
+        texlive-pstricks-doc \
+        texlive-science-doc && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* \
            /tmp/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,3 +34,4 @@ RUN apt-get update && \
            /tmp/* \
            /var/tmp/*
 
+CMD ["/bin/echo", "See https://github.com/lsst-sqre/lsst-texlive for usage."]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: all
+all:
+	docker build -t lsstsqre/lsst-texlive .

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **texlive Docker image for LSST documentation deployment.**
 
+[![Travis branch](https://img.shields.io/travis/lsst-sqre/lsst-texlive/master.svg)](https://travis-ci.org/lsst-sqre/lsst-texlive)
+
 Use ``lsst-texlive`` in a CI environment to speed up build times, or as a replacement for a local texlive installation on your own computer.
 
 **Links:**

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **texlive Docker image for LSST documentation deployment.**
 
-Use ``lsst-texlive`` in a CI environment to speed up build times, or as a replacement for a local lexlive installation on your own computer.
+Use ``lsst-texlive`` in a CI environment to speed up build times, or as a replacement for a local texlive installation on your own computer.
 
 **Links:**
 
@@ -30,6 +30,28 @@ Notes:
 The ``lsst/lsst-texlive`` image is currently based on Ubuntu trusty (14.04).
 It includes ``git``, ``make`` and a comprehensive texlive installation.
 See the Dockerfile for details.
+
+## Developer guide
+
+You can hack on this repo by cloning it and build it using the Makefile:
+
+```bash
+git clone https://github.com/lsst-sqre/lsst-texlive
+cd lsst-texlive
+make all
+docker run --rm lsstsqre/lsst-texlive:latest
+```
+
+This repo uses Travis CI to build and push tagged image to Docker Hub.
+The normal development workflow is:
+
+1. Create a branch.
+2. Commit changes and push to a new branch on GitHub (`git push -u`).
+3. Test your image using the tagged version corresponding to the branch or Travis build number.
+4. To release, make a tag: `git tag -s N.N.N -m "vN.N.N"` and `git push --tags`
+5. Merge to master: `git checkout master && git merge --no-ff <branch>`.
+
+The `latest` tag corresponds to the head of the `master` branch.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # lsst-texlive
-texlive Docker image for LSST documentation
+
+**texlive Docker image for LSST documentation deployment.**
+
+Use ``lsst-texlive`` in a CI environment to speed up build times, or as a replacement for a local lexlive installation on your own computer.
+
+**Links:**
+
+- GitHub repository: https://github.com/lsst-sqre/lsst-texlive
+- Docker Hub: https://hub.docker.com/r/lsstsqre/lsst-texlive/
+
+## Example usage
+
+This example demonstrates how how to build [DMTN-044](https://github.com/lsst-dm/dmtn-044) (a LaTeX-formatted technical note) with `lsst-texlive`.
+
+```bash
+git clone https://github.com/lsst-dm/dmtn-044
+cd dmtn-044
+git submodule init && git submodule update
+docker run --rm -v `pwd`:/workspace -w /workspace lsstsqre/lsst-texlive:latest sh -c 'make'
+```
+
+Notes:
+
+- The `-v` argument binds the current working directory (the technote's source) to the `/workspace` directory in the container.
+- The `-w` argument has the container run the user command (`sh -c make`) from that `workspace` directory.
+
+## What's in it
+
+The ``lsst/lsst-texlive`` image is currently based on Ubuntu trusty (14.04).
+It includes ``git``, ``make`` and a comprehensive texlive installation.
+See the Dockerfile for details.
+
+## License
+
+Copyright 2017 Association of Universities for Research in Astronomy, Inc..
+
+lsst-texlive is MIT-licensed open source. See LICENSE file.

--- a/travis-deploy.sh
+++ b/travis-deploy.sh
@@ -1,0 +1,28 @@
+set -ex
+
+# Manage the image build from Travis CI
+# This assumes that the image is initially built with the "build" tag.
+
+# Skip deployments in PRs
+if [ $TRAVIS_PULL_REQUEST != "false" ]; then
+    exit 0;
+fi
+
+docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+
+# Create tag; latest for master; otherwise use branch name
+if [ "$TRAVIS_BRANCH" == "master" ]; then
+    TAG="latest";
+
+else
+    # need to sanitize any "/" from git branches
+    TAG=`echo "$TRAVIS_BRANCH" | sed "s/\//-/"`;
+fi
+
+# Tag and push the branch-based name
+docker tag ${IMAGE_NAME}:build ${IMAGE_NAME}:${TAG}
+docker push ${IMAGE_NAME}:${TAG}
+
+# Tag and push based on the Travis build number for forensics
+docker tag ${IMAGE_NAME}:build ${IMAGE_NAME}:travis-${TRAVIS_BUILD_NUMBER}
+docker push ${IMAGE_NAME}:travis-${TRAVIS_BUILD_NUMBER}


### PR DESCRIPTION
`lsst-texlive` is a Docker image that contains a complete, ready-to-use texlive installation. This repo project provides a Dockerfile and Travis CI configuration to create Docker images and deploy those images to Docker Hub.

The image is 2.6 GB; some attention could probably trim this by eliminating unneeded packages.

The deployment script is designed so that images are tagged with

- The branch name (or tag name).
- The travis build number (for specific, repeatable images).

Builds against `master` are tagged as `latest`.

This continuous delivery system should make it easy for others in LSST to improve the Docker image without having to deal with Docker Hub configuration.