### PR TITLE
Uprev the base image from trusty to bionic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN apt-get update && \
         texlive-xetex \
         texlive-generic-recommended \
         texlive-full && \
-    # Purge documentation
     apt-get purge -f -y \
         make-doc \
         texlive-fonts-extra-doc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # https://github.com/lsst-sqre/lsst-texlive
 
-FROM ubuntu:trusty
+FROM ubuntu:bionic
 MAINTAINER LSST SQuaRE <sqre-admin@lists.lsst.org>
 
 ENV LANG C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM ubuntu:bionic
 MAINTAINER LSST SQuaRE <sqre-admin@lists.lsst.org>
 
 ENV LANG C.UTF-8
+ENV DEBIAN_FRONTEND noninteractive 
 
 # Matches installation in early Travis PDF installations
 # h/t https://github.com/thomasWeise/docker-texlive/blob/master/image/Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update && \
         texlive-latex-recommended \
         latexmk \
         poppler-utils \
-        latex-xcolor \
         lmodern \
         texlive-xetex \
         texlive-generic-recommended \


### PR DESCRIPTION
This image only makes Python 3.4.3 available, but some of the new documentation tooling uses f-strings.  These require Python 3.7 to function.  I'm suggesting just upping the base image.  I have not tested whether package names have changed in  the interim, but I hope they have not.